### PR TITLE
Update index.jsx to use react v18 syntax + Prop Types

### DIFF
--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import Router from './Router';
 
-render(
-  <Router />,
-  document.getElementById('app'),
-);
+const root = createRoot(document.getElementById('app'));
+
+root.render(<Router />);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "morgan": "1.10.0",
     "path": "0.12.7",
     "pg": "8.7.3",
+    "prop-types": "^15.8.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-router-dom": "^6.3.0"


### PR DESCRIPTION
index.jsx needed a slight syntax change to actually use react v18.

Also prop-types dependency is needed for airbnb linter